### PR TITLE
do not modify data if in a pie chart

### DIFF
--- a/jquery.flot.downsample.js
+++ b/jquery.flot.downsample.js
@@ -100,7 +100,9 @@ THE SOFTWARE.
 
 
     function processRawData ( plot, series ) {
-        series.data = largestTriangleThreeBuckets( series.data, series.downsample.threshold );
+        if ( series.pie === undefined || series.pie.show !== true ) {
+            series.data = largestTriangleThreeBuckets( series.data, series.downsample.threshold );
+        }
     }
 
 


### PR DESCRIPTION
There's no need to call `largestTriangleThreeBuckets` if we are in a pie chart, but the plugin might be loaded for other graphs on the same page...
