### PR TITLE
Add filtering/support for min/max range

### DIFF
--- a/jquery.flot.downsample.js
+++ b/jquery.flot.downsample.js
@@ -98,8 +98,27 @@ THE SOFTWARE.
         return sampled;
     }
 
+    function filterVisibleData( data, series ) {
+        var xmin = series.xaxis.options.min;
+        var xmax = series.xaxis.options.max;
+        var threshold = series.downsample.threshold;
+        
+        if (threshold >= data.length || threshold === 0 || xmin == null || xmax == null) {
+            return data; // Nothing to do
+        }
+
+        /* actual filtering is done via grep function */
+        var filtered = $.grep(data, function(elem, index) {
+            var x = elem[0];
+            //note that we filter only on x, to allow y values to be outside of the visible range
+            return ((xmin <= x) && (x <= xmax));
+        });
+
+        return filtered;
+    }
 
     function processRawData ( plot, series ) {
+        series.data = filterVisibleData(series.data, series);
         series.data = largestTriangleThreeBuckets( series.data, series.downsample.threshold );
     }
 


### PR DESCRIPTION
I suggest to add support to only account for data which is actually visible, i.e. after applying min/max range.

My suggestion is to add a pre-filter. Without that, the graphs will look ugly. 

An example: You have a graph of 4000 data points. You downsample that to a threshold of 800. After zooming in (using e.g. the selection plugin) to a quarter of the graph, you will see only 200 data points, although the range would contain 1000, out of which downsample should rather display 800 data points.
Alternate example: 4000 data points, threshold 800, a 10% range, 80 data points displayed instead of 400.

This way, the point of downsampling is somewhat undermined.

I have prepared a change which fixes that, and skips the added behaviour if min/max are not defined. Note that "out of range" is determined only on x axis, not on y, on purpose - since otherwise threshold plugin might miss some lines to data points outside of the graph.
I tested this only for an ordinary graph (with time series x data), hope that it doesn't break anything else.
