### PR TITLE
Optimization by consolidation and loop reduction

### DIFF
--- a/jquery.flot.downsample.js
+++ b/jquery.flot.downsample.js
@@ -26,6 +26,7 @@ THE SOFTWARE.
     "use strict";
 
     var floor = Math.floor,
+		ceil = Math.ceil,
         abs = Math.abs;
 
     function largestTriangleThreeBuckets(data, threshold) {
@@ -42,7 +43,6 @@ THE SOFTWARE.
         var every = (data_length - 2) / (threshold - 2);
 
         var a = 0,  // Initially a is the first point in the triangle
-            max_area_point,
             max_area,
             area,
             next_a;
@@ -50,12 +50,16 @@ THE SOFTWARE.
         sampled[ sampled_index++ ] = data[ a ]; // Always add the first point
 
         for (var i = 0; i < threshold - 2; i++) {
-
+			// Determine the boundaries for the current and next buckets
+			var bucket_start	= ceil( (i + 0) * every ),
+				bucket_center 	= ceil( (i + 1) * every ),
+				bucket_end 		= ceil( (i + 2) * every );
+				
             // Calculate point average for next bucket (containing c)
             var avg_x = 0,
                 avg_y = 0,
-                avg_range_start  = floor( ( i + 1 ) * every ) + 1,
-                avg_range_end    = floor( ( i + 2 ) * every ) + 1;
+                avg_range_start  = bucket_center,
+                avg_range_end    = bucket_end;
             avg_range_end = avg_range_end < data_length ? avg_range_end : data_length;
 
             var avg_range_length = avg_range_end - avg_range_start;
@@ -68,28 +72,31 @@ THE SOFTWARE.
             avg_y /= avg_range_length;
 
             // Get the range for this bucket
-            var range_offs = floor( (i + 0) * every ) + 1,
-                range_to   = floor( (i + 1) * every ) + 1;
+            var range_offs = bucket_start,
+                range_to   = bucket_center;
 
             // Point a
             var point_a_x = data[ a ][ 0 ] * 1, // enforce Number (value may be Date)
                 point_a_y = data[ a ][ 1 ] * 1;
 
             max_area = area = -1;
-
+			
+			// 2D Vector for A-C
+			var base_x = point_a_x - avg_x,
+				base_y = avg_y - point_a_y;
+				
             for ( ; range_offs < range_to; range_offs++ ) {
                 // Calculate triangle area over three buckets
-                area = abs( ( point_a_x - avg_x ) * ( data[ range_offs ][ 1 ] - point_a_y ) -
-                            ( point_a_x - data[ range_offs ][ 0 ] ) * ( avg_y - point_a_y )
-                          ) * 0.5;
+                area = abs( ( base_x ) * ( data[ range_offs ][ 1 ] - point_a_y ) -
+                            ( point_a_x - data[ range_offs ][ 0 ] ) * ( base_y )
+                          );
                 if ( area > max_area ) {
                     max_area = area;
-                    max_area_point = data[ range_offs ];
                     next_a = range_offs; // Next a is this b
                 }
             }
 
-            sampled[ sampled_index++ ] = max_area_point; // Pick this point from the bucket
+            sampled[ sampled_index++ ] = data[ next_a ]; // Pick this point from the bucket
             a = next_a; // This a is the next a (chosen b)
         }
 

--- a/jquery.flot.downsample.js
+++ b/jquery.flot.downsample.js
@@ -48,13 +48,15 @@ THE SOFTWARE.
             next_a;
 
         sampled[ sampled_index++ ] = data[ a ]; // Always add the first point
-
+		
+		// Determine the boundaries for the current and next buckets
+		var bucket_start	= 0,
+			bucket_center 	= ceil( every );
+			
         for (var i = 0; i < threshold - 2; i++) {
-			// Determine the boundaries for the current and next buckets
-			var bucket_start	= ceil( (i + 0) * every ),
-				bucket_center 	= ceil( (i + 1) * every ),
-				bucket_end 		= ceil( (i + 2) * every );
-				
+			// Calculate the boundary of the third bucket
+			var bucket_end 		= ceil( (i + 2) * every );
+			
             // Calculate point average for next bucket (containing c)
             var avg_x = 0,
                 avg_y = 0,
@@ -98,6 +100,9 @@ THE SOFTWARE.
 
             sampled[ sampled_index++ ] = data[ next_a ]; // Pick this point from the bucket
             a = next_a; // This a is the next a (chosen b)
+			
+			bucket_start 	= bucket_center;	// Shift the buckets over by one
+			bucket_center 	= bucket_end;		// Center becomes the start, and the end becomes the center
         }
 
         sampled[ sampled_index++ ] = data[ data_length - 1 ]; // Always add last


### PR DESCRIPTION
Some operations were repeated each loop when they really don't need to be.
The number is not needed to be an exact area but a number we can compare to, omitting the division saves an operation each loop, and nothing is lost.
Initializing the bucket boundaries saves two extra calculations each bucket loop, and only the newest edge needs to be generated.
Changing to ceil over floor+1 gives the same effective result.
