### PR TITLE
:sparkles: add tsdownsample + MinMaxLTTB paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Articles related to the algorithm (LTTB)
 * [Downsampling algorithms](http://www.adrian.idv.hk/2018-01-24-downsample/) by Adrian S. Tam
 * [Plot your data faster without losing its shape with Elixir and ExLTTB](https://blog.ispirata.com/plot-your-data-faster-without-losing-its-shape-with-elixir-and-exlttb-6917f6dd4f7e) by Riccardo Binetti
 * [Implementation of Downsampling Algorithm in MSChart Extension](https://www.codearteng.com/2020/08/implementation-of-downsampling.html) by Code Artist
-
+* [MinMaxLTTB: Leveraging MinMax-Preselection to Scale LTTB](https://arxiv.org/abs/2305.00332) by Jeroen & Jonas Van Der Donckt
 
 The algorithm (LTTB) adapted for other programming languages or frameworks
 -----
@@ -72,6 +72,7 @@ The algorithm (LTTB) adapted for other programming languages or frameworks
 * [Python](https://github.com/devoxi/lttb-py) by Olivier Devoisin
 * [Python + Numpy](https://github.com/javiljoen/lttb.py) by Jack Viljoen
 * [Python using C](https://github.com/dgoeries/lttbc) by dgoeries
+* [Python using Rust](https://github.com/predict-idlab/tsdownsample) by Jeroen Van Der Donckt
 * [Perl](https://github.com/troxel/LargestTriangleThreeBuckets) by troxel
 * [C++](https://github.com/parkertomatoes/lttb-cpp) by parkertomatoes
 * [Ruby](https://github.com/Jubke/lttb) by Julian Lübke


### PR DESCRIPTION
This PR adds 
* [`tsdownsample`](https://github.com/predict-idlab/tsdownsample) under the code section of the README - [`tsdownsample`](https://github.com/predict-idlab/tsdownsample) provides (extremely) optimized pre-compiled implementations of the LTTB & MinMaxLTTB algorithm (for in-memory downsampling)
* [our research paper on MinMaxLTTB](https://arxiv.org/abs/2305.00332) which is a new heuristic for the LTTB algorithm that has much better runtime, allows for parallelization, can be easily implemented in database solutions *while* serving the same visual representativeness as the vanilla LTTB algorithm!

@sveinn-steinarsson your thesis on time series downsampling largely inspired most of the work above - you are a legend for laying the foundation in the time series downsampling for visualization domain.